### PR TITLE
nixos/testing: Propagate meta attributes.

### DIFF
--- a/nixos/lib/testing.nix
+++ b/nixos/lib/testing.nix
@@ -122,14 +122,16 @@ rec {
             ${lib.optionalString (builtins.length vms == 1) "--set USE_SERIAL 1"}
         ''; # "
 
-      test = runTests driver;
+      passMeta = drv: drv // lib.optionalAttrs (t ? meta) {
+        meta = (drv.meta or {}) // t.meta;
+      };
 
-      report = releaseTools.gcovReport { coverageRuns = [ test ]; };
+      test = passMeta (runTests driver);
+
+      report = passMeta (releaseTools.gcovReport { coverageRuns = [ test ]; });
 
     in (if makeCoverageReport then report else test) // {
       inherit nodes driver test;
-    } // lib.optionalAttrs (t ? meta) {
-      inherit (t) meta;
     };
 
 

--- a/nixos/lib/testing.nix
+++ b/nixos/lib/testing.nix
@@ -126,7 +126,11 @@ rec {
 
       report = releaseTools.gcovReport { coverageRuns = [ test ]; };
 
-    in (if makeCoverageReport then report else test) // { inherit nodes driver test; };
+    in (if makeCoverageReport then report else test) // {
+      inherit nodes driver test;
+    } // lib.optionalAttrs (t ? meta) {
+      inherit (t) meta;
+    };
 
 
   runInMachine =

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -358,7 +358,5 @@ in rec {
         services.postgresql.package = pkgs.postgresql93;
         environment.systemPackages = [ pkgs.php ];
       });
-
   };
-
 }

--- a/nixos/tests/avahi.nix
+++ b/nixos/tests/avahi.nix
@@ -1,7 +1,9 @@
 # Test whether `avahi-daemon' and `libnss-mdns' work as expected.
-
-import ./make-test.nix {
+import ./make-test.nix ({ pkgs, ... } : {
   name = "avahi";
+  meta = with pkgs.stdenv.lib; {
+    maintainers = [ eelco chaoflow wizeman ];
+  };
 
   nodes = {
     one =
@@ -52,4 +54,4 @@ import ./make-test.nix {
        $two->succeed("getent hosts one.local >&2");
        $two->succeed("getent hosts two.local >&2");
     '';
-}
+})

--- a/nixos/tests/bittorrent.nix
+++ b/nixos/tests/bittorrent.nix
@@ -24,6 +24,9 @@ in
 
 {
   name = "bittorrent";
+  meta = with pkgs.stdenv.lib; {
+    maintainers = [ iElectric eelco chaoflow rob wkennington ];
+  };
 
   nodes =
     { tracker =

--- a/nixos/tests/blivet.nix
+++ b/nixos/tests/blivet.nix
@@ -1,5 +1,8 @@
 import ./make-test.nix ({ pkgs, ... }: with pkgs.pythonPackages; rec {
   name = "blivet";
+  meta = with pkgs.stdenv.lib; {
+    maintainers = [ aszlig ];
+  };
 
   machine = {
     environment.systemPackages = [ pkgs.python blivet mock ];

--- a/nixos/tests/cadvisor.nix
+++ b/nixos/tests/cadvisor.nix
@@ -1,5 +1,8 @@
-import ./make-test.nix {
+import ./make-test.nix ({ pkgs, ... } : {
   name = "cadvisor";
+  meta = with pkgs.stdenv.lib; {
+    maintainers = [ offline ];
+  };
 
   nodes = {
     machine = { config, pkgs, ... }: {
@@ -27,4 +30,4 @@ import ./make-test.nix {
       $influxdb->waitForUnit("cadvisor.service");
       $influxdb->succeed("curl http://localhost:8080/containers/");
     '';
-}
+})

--- a/nixos/tests/check-filesystems.nix
+++ b/nixos/tests/check-filesystems.nix
@@ -7,6 +7,9 @@ with import ../lib/build-vms.nix { inherit nixos nixpkgs system; };
 
 rec {
   name = "check-filesystems";
+  meta = with pkgs.stdenv.lib; {
+    maintainers = [ eelco chaoflow ];
+  };
 
   nodes = {
     share = {pkgs, config, ...}: {

--- a/nixos/tests/chromium.nix
+++ b/nixos/tests/chromium.nix
@@ -8,6 +8,9 @@ import ./make-test.nix (
 , ...
 }: rec {
   name = "chromium";
+  meta = with pkgs.stdenv.lib; {
+    maintainers = [ aszlig ];
+  };
 
   enableOCR = true;
 

--- a/nixos/tests/cjdns.nix
+++ b/nixos/tests/cjdns.nix
@@ -22,8 +22,11 @@ let
 
 in
 
-import ./make-test.nix {
+import ./make-test.nix ({ pkgs, ...} : {
   name = "cjdns";
+  meta = with pkgs.stdenv.lib; {
+    maintainers = [ emery ];
+  };
 
   nodes = rec
     { # Alice finds peers over over ETHInterface.
@@ -119,4 +122,4 @@ import ./make-test.nix {
 
       $bob->succeed("curl --fail -g http://[$aliceIp6]");
     '';
-}
+})

--- a/nixos/tests/containers.nix
+++ b/nixos/tests/containers.nix
@@ -1,7 +1,10 @@
 # Test for NixOS' container support.
 
-import ./make-test.nix {
+import ./make-test.nix ({ pkgs, ...} : {
   name = "containers";
+  meta = with pkgs.stdenv.lib; {
+    maintainers = [ aristid aszlig eelco chaoflow ];
+  };
 
   machine =
     { config, pkgs, ... }:
@@ -113,4 +116,4 @@ import ./make-test.nix {
       $machine->fail("nixos-container destroy webserver");
     '';
 
-}
+})

--- a/nixos/tests/docker-registry.nix
+++ b/nixos/tests/docker-registry.nix
@@ -1,7 +1,10 @@
 # This test runs docker-registry and check if it works
 
-import ./make-test.nix {
+import ./make-test.nix ({ pkgs, ...} : {
   name = "docker-registry";
+  meta = with pkgs.stdenv.lib; {
+    maintainers = [ offline ];
+  };
 
   nodes = {
     registry = { config, pkgs, ... }: {
@@ -37,4 +40,4 @@ import ./make-test.nix {
     $client2->succeed("docker pull registry:8080/scratch");
     $client2->succeed("docker images | grep scratch");
   '';
-}
+})

--- a/nixos/tests/docker.nix
+++ b/nixos/tests/docker.nix
@@ -1,7 +1,10 @@
 # This test runs docker and checks if simple container starts
 
-import ./make-test.nix {
+import ./make-test.nix ({ pkgs, ...} : {
   name = "docker";
+  meta = with pkgs.stdenv.lib; {
+    maintainers = [ offline ];
+  };
 
   nodes = {
     docker =
@@ -20,5 +23,4 @@ import ./make-test.nix {
     $docker->succeed("docker ps | grep sleeping");
     $docker->succeed("docker stop sleeping");
   '';
-
-}
+})

--- a/nixos/tests/etcd.nix
+++ b/nixos/tests/etcd.nix
@@ -1,7 +1,10 @@
 # This test runs etcd as single node, multy node and using discovery
 
-import ./make-test.nix {
+import ./make-test.nix ({ pkgs, ... } : {
   name = "etcd";
+  meta = with pkgs.stdenv.lib; {
+    maintainers = [ offline ];
+  };
 
   nodes = {
     simple =
@@ -105,4 +108,4 @@ import ./make-test.nix {
       $discovery2->waitUntilSucceeds("etcdctl get /foo/bar | grep 'Hello world'");
     };
   '';
-}
+})

--- a/nixos/tests/firefox.nix
+++ b/nixos/tests/firefox.nix
@@ -1,5 +1,8 @@
 import ./make-test.nix ({ pkgs, ... }: {
   name = "firefox";
+  meta = with pkgs.stdenv.lib; {
+    maintainers = [ eelco chaoflow shlevy ];
+  };
 
   machine =
     { config, pkgs, ... }:

--- a/nixos/tests/firewall.nix
+++ b/nixos/tests/firewall.nix
@@ -1,7 +1,10 @@
 # Test the firewall module.
 
-import ./make-test.nix {
+import ./make-test.nix ( { pkgs, ... } : {
   name = "firewall";
+  meta = with pkgs.stdenv.lib; {
+    maintainers = [ eelco chaoflow ];
+  };
 
   nodes =
     { walled =
@@ -44,5 +47,4 @@ import ./make-test.nix {
       $walled->stopJob("firewall");
       $attacker->succeed("curl -v http://walled/ >&2");
     '';
-
-}
+})

--- a/nixos/tests/fleet.nix
+++ b/nixos/tests/fleet.nix
@@ -1,5 +1,8 @@
-import ./make-test.nix rec {
+import ./make-test.nix ({ pkgs, ...} : rec {
   name = "simple";
+  meta = with pkgs.stdenv.lib; {
+    maintainers = [ offline ];
+  };
 
   nodes = {
     node1 =
@@ -70,4 +73,4 @@ import ./make-test.nix rec {
       $node1->succeed("fleetctl stop hello.service");
       $node1->succeed("fleetctl destroy hello.service");
     '';
-}
+})

--- a/nixos/tests/gitlab.nix
+++ b/nixos/tests/gitlab.nix
@@ -1,7 +1,10 @@
 # This test runs gitlab and checks if it works
 
-import ./make-test.nix {
+import ./make-test.nix ({ pkgs, ...} : {
   name = "gitlab";
+  meta = with pkgs.stdenv.lib; {
+    maintainers = [ iElectric offline ];
+  };
 
   nodes = {
     gitlab = { config, pkgs, ... }: {
@@ -18,4 +21,4 @@ import ./make-test.nix {
     $gitlab->waitForUnit("gitlab-sidekiq.service");
     $gitlab->waitUntilSucceeds("curl http://localhost:8080/users/sign_in");
   '';
-}
+})

--- a/nixos/tests/gnome3.nix
+++ b/nixos/tests/gnome3.nix
@@ -1,5 +1,8 @@
-import ./make-test.nix {
+import ./make-test.nix ({ pkgs, ...} : {
   name = "gnome3";
+  meta = with pkgs.stdenv.lib; {
+    maintainers = [ iElectric eelco chaoflow lethalman ];
+  };
 
   machine =
     { config, pkgs, ... }:
@@ -28,5 +31,4 @@ import ./make-test.nix {
       $machine->sleep(20);
       $machine->screenshot("screen");
     '';
-
-}
+})

--- a/nixos/tests/i3wm.nix
+++ b/nixos/tests/i3wm.nix
@@ -1,5 +1,8 @@
-import ./make-test.nix {
+import ./make-test.nix ({ pkgs, ...} : {
   name = "i3wm";
+  meta = with pkgs.stdenv.lib; {
+    maintainers = [ aszlig ];
+  };
 
   machine = { lib, pkgs, ... }: {
     imports = [ ./common/x11.nix ./common/user-account.nix ];
@@ -25,4 +28,4 @@ import ./make-test.nix {
     $machine->sleep(1);
     $machine->screenshot("terminal");
   '';
-}
+})

--- a/nixos/tests/influxdb.nix
+++ b/nixos/tests/influxdb.nix
@@ -1,7 +1,10 @@
 # This test runs influxdb and checks if influxdb is up and running
 
-import ./make-test.nix {
+import ./make-test.nix ({ pkgs, ...} : {
   name = "influxdb";
+  meta = with pkgs.stdenv.lib; {
+    maintainers = [ chaoflow offline ];
+  };
 
   nodes = {
     one = { config, pkgs, ... }: {
@@ -33,4 +36,4 @@ import ./make-test.nix {
         --data-urlencode 'q=select * from foo limit 1' | grep 6666
     ~);
   '';
-}
+})

--- a/nixos/tests/ipv6.nix
+++ b/nixos/tests/ipv6.nix
@@ -1,8 +1,11 @@
 # Test of IPv6 functionality in NixOS, including whether router
 # solicication/advertisement using radvd works.
 
-import ./make-test.nix {
+import ./make-test.nix ({ pkgs, ...} : {
   name = "ipv6";
+  meta = with pkgs.stdenv.lib; {
+    maintainers = [ eelco chaoflow ];
+  };
 
   nodes =
     { client = { config, pkgs, ... }: { };
@@ -73,5 +76,4 @@ import ./make-test.nix {
 
       # TODO: test reachability of a machine on another network.
     '';
-
-}
+})

--- a/nixos/tests/jenkins.nix
+++ b/nixos/tests/jenkins.nix
@@ -3,8 +3,11 @@
 #   2. jenkins user can be extended on both master and slave
 #   3. jenkins service not started on slave node
 
-import ./make-test.nix {
+import ./make-test.nix ({ pkgs, ...} : {
   name = "jenkins";
+  meta = with pkgs.stdenv.lib; {
+    maintainers = [ bjornfor coconnor iElectric eelco chaoflow ];
+  };
 
   nodes = {
 
@@ -41,4 +44,4 @@ import ./make-test.nix {
 
     $slave->mustFail("systemctl is-enabled jenkins.service");
   '';
-}
+})

--- a/nixos/tests/kde4.nix
+++ b/nixos/tests/kde4.nix
@@ -1,5 +1,8 @@
 import ./make-test.nix ({ pkgs, ... }: {
   name = "kde4";
+  meta = with pkgs.stdenv.lib; {
+    maintainers = [ iElectric eelco chaoflow ];
+  };
 
   machine =
     { config, pkgs, ... }:

--- a/nixos/tests/kexec.nix
+++ b/nixos/tests/kexec.nix
@@ -1,7 +1,10 @@
 # Test whether fast reboots via kexec work.
 
-import ./make-test.nix  {
+import ./make-test.nix ({ pkgs, ...} : {
   name = "kexec";
+  meta = with pkgs.stdenv.lib; {
+    maintainers = [ eelco chaoflow ];
+  };
 
   machine = { config, pkgs, ... }:
     { virtualisation.vlans = [ ]; };
@@ -13,5 +16,4 @@ import ./make-test.nix  {
       $machine->{connected} = 0;
       $machine->waitForUnit("multi-user.target");
     '';
-
-}
+})

--- a/nixos/tests/kubernetes.nix
+++ b/nixos/tests/kubernetes.nix
@@ -1,7 +1,10 @@
 # This test runs two node kubernetes cluster and checks if simple redis pod works
 
-import ./make-test.nix rec {
+import ./make-test.nix ({ pkgs, ...} : rec {
   name = "kubernetes";
+  meta = with pkgs.stdenv.lib; {
+    maintainers = [ offline ];
+  };
 
   redisMaster = builtins.toFile "redis-master-pod.yaml" ''
       id: redis-master-pod
@@ -176,4 +179,4 @@ import ./make-test.nix rec {
     }
 
   '';
-}
+})

--- a/nixos/tests/lightdm.nix
+++ b/nixos/tests/lightdm.nix
@@ -1,5 +1,8 @@
-import ./make-test.nix {
+import ./make-test.nix ({ pkgs, ...} : {
   name = "lightdm";
+  meta = with pkgs.stdenv.lib; {
+    maintainers = [ aszlig ];
+  };
 
   machine = { lib, ... }: {
     imports = [ ./common/user-account.nix ];
@@ -22,4 +25,4 @@ import ./make-test.nix {
     $machine->waitForText(qr/^\d{2}(?::\d{2}){2} (?:AM|PM)$/m);
     $machine->screenshot("session");
   '';
-}
+})

--- a/nixos/tests/login.nix
+++ b/nixos/tests/login.nix
@@ -2,6 +2,9 @@ import ./make-test.nix ({ pkgs, latestKernel ? false, ... }:
 
 {
   name = "login";
+  meta = with pkgs.stdenv.lib; {
+    maintainers = [ eelco chaoflow ];
+  };
 
   machine =
     { config, pkgs, lib, ... }:

--- a/nixos/tests/logstash.nix
+++ b/nixos/tests/logstash.nix
@@ -1,8 +1,11 @@
 # This test runs logstash and checks if messages flows and
 # elasticsearch is started.
 
-import ./make-test.nix {
+import ./make-test.nix ({ pkgs, ...} : {
   name = "logstash";
+  meta = with pkgs.stdenv.lib; {
+    maintainers = [ eelco chaoflow offline ];
+  };
 
   nodes = {
     one =
@@ -37,4 +40,4 @@ import ./make-test.nix {
     $one->fail("journalctl -n 20 _SYSTEMD_UNIT=logstash.service | grep dragons");
     $one->waitUntilSucceeds("curl -s http://127.0.0.1:9200/_status?pretty=true | grep logstash");
   '';
-}
+})

--- a/nixos/tests/mesos.nix
+++ b/nixos/tests/mesos.nix
@@ -1,5 +1,8 @@
-import ./make-test.nix {
+import ./make-test.nix ({ pkgs, ...} : {
   name = "simple";
+  meta = with pkgs.stdenv.lib; {
+    maintainers = [ offline ];
+  };
 
   machine = { config, pkgs, ... }: {
     services.zookeeper.enable = true;
@@ -26,4 +29,4 @@ import ./make-test.nix {
       $machine->waitForUnit("mesos-master.service");
       $machine->waitForUnit("mesos-slave.service");
     '';
-}
+})

--- a/nixos/tests/misc.nix
+++ b/nixos/tests/misc.nix
@@ -1,7 +1,10 @@
 # Miscellaneous small tests that don't warrant their own VM run.
 
-import ./make-test.nix {
+import ./make-test.nix ({ pkgs, ...} : {
   name = "misc";
+  meta = with pkgs.stdenv.lib; {
+    maintainers = [ eelco chaoflow ];
+  };
 
   machine =
     { config, lib, pkgs, ... }:
@@ -107,5 +110,4 @@ import ./make-test.nix {
           $machine->succeed("nix-store -qR /run/current-system | grep nixos-");
       };
     '';
-
-}
+})

--- a/nixos/tests/mpich.nix
+++ b/nixos/tests/mpich.nix
@@ -1,7 +1,10 @@
 # Simple example to showcase distributed tests using NixOS VMs.
 
-import ./make-test.nix {
+import ./make-test.nix ({ pkgs, ...} : {
   name = "mpich";
+  meta = with pkgs.stdenv.lib; {
+    maintainers = [ eelco chaoflow ];
+  };
 
   nodes = {
     master =
@@ -35,4 +38,4 @@ import ./make-test.nix {
 
        $master->succeed("mpiexec -n 2 ./example >&2");
     '';
-}
+})

--- a/nixos/tests/mumble.nix
+++ b/nixos/tests/mumble.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix (
+import ./make-test.nix ({ pkgs, ...} : 
 
 let
   client = { config, pkgs, ... }: {
@@ -8,6 +8,9 @@ let
 in
 {
   name = "mumble";
+  meta = with pkgs.stdenv.lib; {
+    maintainers = [ thoughtpolice eelco chaoflow ];
+  };
 
   nodes = {
     server = { config, pkgs, ... }: {

--- a/nixos/tests/munin.nix
+++ b/nixos/tests/munin.nix
@@ -1,8 +1,11 @@
 # This test runs basic munin setup with node and cron job running on the same
 # machine.
 
-import ./make-test.nix {
+import ./make-test.nix ({ pkgs, ...} : {
   name = "munin";
+  meta = with pkgs.stdenv.lib; {
+    maintainers = [ iElectric eelco chaoflow ];
+  };
 
   nodes = {
     one =
@@ -29,4 +32,4 @@ import ./make-test.nix {
     $one->waitForFile("/var/lib/munin/one/one-uptime-uptime-g.rrd");
     $one->waitForFile("/var/www/munin/one/index.html");
   '';
-}
+})

--- a/nixos/tests/mysql-replication.nix
+++ b/nixos/tests/mysql-replication.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix (
+import ./make-test.nix ({ pkgs, ...} :
 
 let
   replicateUser = "replicate";
@@ -7,6 +7,9 @@ in
 
 {
   name = "mysql-replication";
+  meta = with pkgs.stdenv.lib; {
+    maintainers = [ eelco chaoflow shlevy ];
+  };
 
   nodes = {
     master =

--- a/nixos/tests/mysql.nix
+++ b/nixos/tests/mysql.nix
@@ -1,5 +1,8 @@
-import ./make-test.nix {
+import ./make-test.nix ({ pkgs, ...} : {
   name = "mysql";
+  meta = with pkgs.stdenv.lib; {
+    maintainers = [ eelco chaoflow shlevy ];
+  };
 
   nodes = {
     master =
@@ -20,4 +23,4 @@ import ./make-test.nix {
     $master->sleep(10); # Hopefully this is long enough!!
     $master->succeed("echo 'use testdb; select * from tests' | mysql -u root -N | grep 4");
   '';
-}
+})

--- a/nixos/tests/nat.nix
+++ b/nixos/tests/nat.nix
@@ -3,12 +3,15 @@
 # client on the inside network, a server on the outside network, and a
 # router connected to both that performs Network Address Translation
 # for the client.
-import ./make-test.nix ({ withFirewall, ... }:
+import ./make-test.nix ({ pkgs, withFirewall, ... }:
   let
     unit = if withFirewall then "firewall" else "nat";
   in
   {
     name = "nat${if withFirewall then "WithFirewall" else "Standalone"}";
+    meta = with pkgs.stdenv.lib; {
+      maintainers = [ eelco chaoflow rob wkennington ];
+    };
 
     nodes =
       { client =

--- a/nixos/tests/networking-proxy.nix
+++ b/nixos/tests/networking-proxy.nix
@@ -10,8 +10,11 @@ let default-config = {
 
         virtualisation.memorySize = 128;
       };
-in import ./make-test.nix {
+in import ./make-test.nix ({ pkgs, ...} : {
   name = "networking-proxy";
+  meta = with pkgs.stdenv.lib; {
+    maintainers = [  ];
+  };
 
   nodes = {
     # no proxy
@@ -105,5 +108,4 @@ in import ./make-test.nix {
       $machine4->mustSucceed("su - alice -c 'env | grep -i ftp_proxy | grep 000'");
       $machine4->mustSucceed("su - alice -c 'env | grep -i no_proxy | grep 131415'");
     '';
-
-}
+})

--- a/nixos/tests/networking.nix
+++ b/nixos/tests/networking.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ networkd, test, ... }:
+import ./make-test.nix ({ pkgs, networkd, test, ... }:
   let
     router = { config, pkgs, ... }:
       with pkgs.lib;

--- a/nixos/tests/nfs.nix
+++ b/nixos/tests/nfs.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ version ? 4, ... }:
+import ./make-test.nix ({ pkgs, version ? 4, ... }:
 
 let
 
@@ -18,6 +18,9 @@ in
 
 {
   name = "nfs";
+  meta = with pkgs.stdenv.lib; {
+    maintainers = [ eelco chaoflow wkennington ];
+  };
 
   nodes =
     { client1 = client;
@@ -83,5 +86,4 @@ in
       my $duration = time - $t1;
       die "shutdown took too long ($duration seconds)" if $duration > 30;
     '';
-
 })

--- a/nixos/tests/nsd.nix
+++ b/nixos/tests/nsd.nix
@@ -5,8 +5,11 @@ let
     # for a host utility with IPv6 support
     environment.systemPackages = [ pkgs.bind ];
   };
-in import ./make-test.nix {
+in import ./make-test.nix ({ pkgs, ...} : {
   name = "nsd";
+  meta = with pkgs.stdenv.lib; {
+    maintainers = [ aszlig ];
+  };
 
   nodes = {
     clientv4 = { lib, nodes, ... }: {
@@ -80,4 +83,4 @@ in import ./make-test.nix {
       };
     }
   '';
-}
+})

--- a/nixos/tests/openssh.nix
+++ b/nixos/tests/openssh.nix
@@ -17,6 +17,9 @@ let
 
 in {
   name = "openssh";
+  meta = with pkgs.stdenv.lib; {
+    maintainers = [ aszlig eelco chaoflow ];
+  };
 
   nodes = {
 

--- a/nixos/tests/panamax.nix
+++ b/nixos/tests/panamax.nix
@@ -1,5 +1,8 @@
-import ./make-test.nix {
+import ./make-test.nix ({ pkgs, ...} : {
   name = "panamax";
+  meta = with pkgs.stdenv.lib; {
+    maintainers = [ offline ];
+  };
 
   machine = { config, pkgs, ... }: {
     services.panamax.enable = true;
@@ -15,4 +18,4 @@ import ./make-test.nix {
       $machine->succeed("curl --fail http://localhost:8888/ > /dev/null");
       $machine->shutdown;
     '';
-}
+})

--- a/nixos/tests/peerflix.nix
+++ b/nixos/tests/peerflix.nix
@@ -1,7 +1,10 @@
 # This test runs peerflix and checks if peerflix starts
 
-import ./make-test.nix {
+import ./make-test.nix ({ pkgs, ...} : {
   name = "peerflix";
+  meta = with pkgs.stdenv.lib; {
+    maintainers = [ offline ];
+  };
 
   nodes = {
     peerflix =
@@ -17,5 +20,4 @@ import ./make-test.nix {
     $peerflix->waitForUnit("peerflix.service");
     $peerflix->waitUntilSucceeds("curl localhost:9000");
   '';
-
-}
+})

--- a/nixos/tests/phabricator.nix
+++ b/nixos/tests/phabricator.nix
@@ -1,5 +1,8 @@
 import ./make-test.nix ({ pkgs, ... }: {
   name = "phabricator";
+  meta = with pkgs.stdenv.lib; {
+    maintainers = [ chaoflow ];
+  };
 
   nodes = {
     storage =

--- a/nixos/tests/printing.nix
+++ b/nixos/tests/printing.nix
@@ -2,6 +2,9 @@
 
 import ./make-test.nix ({pkgs, ... }: {
   name = "printing";
+  meta = with pkgs.stdenv.lib; {
+    maintainers = [ iElectric eelco chaoflow jgeerds vcunat ];
+  };
 
   nodes = {
 
@@ -90,5 +93,4 @@ import ./make-test.nix ({pkgs, ... }: {
           };
       }
     '';
-
 })

--- a/nixos/tests/proxy.nix
+++ b/nixos/tests/proxy.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix (
+import ./make-test.nix ({ pkgs, ...} : 
 
 let
 
@@ -15,6 +15,9 @@ in
 
 {
   name = "proxy";
+  meta = with pkgs.stdenv.lib; {
+    maintainers = [ eelco chaoflow ];
+  };
 
   nodes =
     { proxy =
@@ -89,5 +92,4 @@ in
       $backend2->unblock;
       $client->succeed("curl --fail http://proxy/");
     '';
-
 })

--- a/nixos/tests/quake3.nix
+++ b/nixos/tests/quake3.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix (
+import ./make-test.nix ({ pkgs, ...} :
 
 let
 
@@ -14,6 +14,9 @@ in
 
 rec {
   name = "quake3";
+  meta = with pkgs.stdenv.lib; {
+    maintainers = [ iElectric eelco chaoflow ];
+  };
 
   # TODO: lcov doesn't work atm
   #makeCoverageReport = true;

--- a/nixos/tests/rabbitmq.nix
+++ b/nixos/tests/rabbitmq.nix
@@ -2,6 +2,9 @@
 
 import ./make-test.nix ({ pkgs, ... }: {
   name = "rabbitmq";
+  meta = with pkgs.stdenv.lib; {
+    maintainers = [ eelco chaoflow offline ];
+  };
 
   nodes = {
     one = { config, pkgs, ... }: {

--- a/nixos/tests/simple.nix
+++ b/nixos/tests/simple.nix
@@ -1,5 +1,8 @@
-import ./make-test.nix {
+import ./make-test.nix ({ pkgs, ...} : {
   name = "simple";
+  meta = with pkgs.stdenv.lib; {
+    maintainers = [ eelco ];
+  };
 
   machine = { config, pkgs, ... }: { };
 
@@ -9,4 +12,4 @@ import ./make-test.nix {
       $machine->waitForUnit("multi-user.target");
       $machine->shutdown;
     '';
-}
+})

--- a/nixos/tests/subversion.nix
+++ b/nixos/tests/subversion.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix (
+import ./make-test.nix ({ pkgs, ...} : 
 
 let
 
@@ -33,6 +33,9 @@ in
 
 {
   name = "subversion";
+  meta = with pkgs.stdenv.lib; {
+    maintainers = [ eelco chaoflow ];
+  };
 
   nodes =
     { webserver =

--- a/nixos/tests/tomcat.nix
+++ b/nixos/tests/tomcat.nix
@@ -1,5 +1,8 @@
-import ./make-test.nix {
+import ./make-test.nix ({ pkgs, ...} : {
   name = "tomcat";
+  meta = with pkgs.stdenv.lib; {
+    maintainers = [ eelco chaoflow ];
+  };
 
   nodes = {
     server =
@@ -25,5 +28,4 @@ import ./make-test.nix {
     $client->succeed("curl --fail http://server/examples/servlets/servlet/HelloWorldExample");
     $client->succeed("curl --fail http://server/examples/jsp/jsp2/simpletag/hello.jsp");
   '';
-
-}
+})

--- a/nixos/tests/trac.nix
+++ b/nixos/tests/trac.nix
@@ -1,5 +1,8 @@
 import ./make-test.nix ({ pkgs, ... }: {
   name = "trac";
+  meta = with pkgs.stdenv.lib; {
+    maintainers = [ eelco chaoflow ];
+  };
 
   nodes = {
     storage =

--- a/nixos/tests/udisks2.nix
+++ b/nixos/tests/udisks2.nix
@@ -11,6 +11,9 @@ in
 
 {
   name = "udisks2";
+  meta = with pkgs.stdenv.lib; {
+    maintainers = [ eelco chaoflow ];
+  };
 
   machine =
     { config, pkgs, ... }:

--- a/nixos/tests/virtualbox.nix
+++ b/nixos/tests/virtualbox.nix
@@ -298,6 +298,9 @@ import ./make-test.nix ({ pkgs, ... }: with pkgs.lib; let
 
 in {
   name = "virtualbox";
+  meta = with pkgs.stdenv.lib; {
+    maintainers = [ aszlig wkennington ];
+  };
 
   machine = { pkgs, lib, config, ... }: {
     imports = let

--- a/nixos/tests/xfce.nix
+++ b/nixos/tests/xfce.nix
@@ -1,5 +1,8 @@
-import ./make-test.nix {
+import ./make-test.nix ({ pkgs, ...} : {
   name = "xfce";
+  meta = with pkgs.stdenv.lib; {
+    maintainers = [ eelco chaoflow shlevy ];
+  };
 
   machine =
     { config, pkgs, ... }:
@@ -28,5 +31,4 @@ import ./make-test.nix {
       $machine->sleep(10);
       $machine->screenshot("screen");
     '';
-
-}
+})


### PR DESCRIPTION
As mentioned by @lethalman in #8163.

This ensures that meta attributes defined in the test arguments are propagated to the resulting derivation's attributes so that we actually get failure/success notifications from Hydra.
